### PR TITLE
refactor: Ghostbusters logo css animation audit fixes

### DIFF
--- a/src/pens/css/ghostbusters-logo-css-animation/index.html
+++ b/src/pens/css/ghostbusters-logo-css-animation/index.html
@@ -13,24 +13,19 @@
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>
-        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+        <main>
         <svg
+            role="img"
+            aria-labelledby="svg-title"
             width="100%"
             height="100%"
             viewBox="0 0 1050 913"
             version="1.1"
             xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
             xml:space="preserve"
             xmlns:serif="http://www.serif.com/"
-            style="
-                fill-rule: evenodd;
-                clip-rule: evenodd;
-                stroke-linejoin: round;
-                stroke-miterlimit: 2;
-            "
         >
+            <title id="svg-title">Ghostbusters logo</title>
             <g id="ghostbusters_logo">
                 <g id="circle">
                     <path
@@ -67,5 +62,6 @@
                 </g>
             </g>
         </svg>
+        </main>
     </body>
 </html>

--- a/src/pens/css/ghostbusters-logo-css-animation/style.css
+++ b/src/pens/css/ghostbusters-logo-css-animation/style.css
@@ -3,24 +3,26 @@ body {
     align-items: center;
     background-color: #322f32;
     display: flex;
-    height: 100vh;
+    min-height: 100svh;
     justify-content: center;
     margin: 0;
+    overflow: clip;
 }
 
-#ghostbusters_logo {
-    height: 80vh;
-    justify-content: center;
+main {
+    display: contents;
 }
 
-@keyframes logo-glow {
-    0%,
-    95% {
-        filter: none;
-    }
-    100% {
-        filter: drop-shadow(0 0 22px rgba(255, 255, 255, 0.9)) blur(1px);
-    }
+svg {
+    fill-rule: evenodd;
+    clip-rule: evenodd;
+    stroke-linejoin: round;
+    stroke-miterlimit: 2;
+    max-height: 80vh;
+    max-width: 90vw;
+    height: auto;
+    width: auto;
+    overflow: visible;
 }
 
 #circle {
@@ -42,16 +44,8 @@ body {
     filter: drop-shadow(0 0 22px rgba(255, 255, 255, 0.9)) blur(1px);
     animation: ghost-in 700ms 1100ms cubic-bezier(0.22, 1, 0.36, 1) both,
         ghost-glow 1400ms 1100ms ease-out forwards;
-
     mask: url(#ghostVaporMask);
     -webkit-mask: url(#ghostVaporMask);
-
-    /* Fade + glow shrink */
-    animation: ghost-in 700ms 1100ms cubic-bezier(0.22, 1, 0.36, 1) both,
-        ghost-glow 1400ms 1100ms ease-out forwards;
-
-    /* Initial glow */
-    filter: drop-shadow(0 0 22px rgba(255, 255, 255, 0.9)) blur(1px);
 }
 
 @keyframes ghost-glow {
@@ -117,10 +111,3 @@ body {
     }
 }
 
-#ghostbusters_logo {
-    animation-play-state: paused;
-}
-
-#ghostbusters_logo:hover {
-    animation-play-state: running;
-}


### PR DESCRIPTION
- add `main` landmark
- remove unused animations and classes
- add SVG title
- remove unneeded tags and meta