### PR TITLE
refactor: fixes for build a Wikipedia viewer

### DIFF
--- a/src/pens/fcc-projects/build-a-wikipedia-viewer/css/styles.css
+++ b/src/pens/fcc-projects/build-a-wikipedia-viewer/css/styles.css
@@ -24,9 +24,6 @@ h3 a {
     text-decoration: none;
 }
 
-h3 a:hover {
-    color: var(--light-blue);
-}
 
 p {
     font-size: 1.1em;
@@ -51,12 +48,14 @@ form {
 }
 
 input[type="text"] {
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2),
+    box-shadow:
+        0 1px 2px 0 rgba(0, 0, 0, 0.2),
         0 1.5px 2px 0 rgba(0, 0, 0, 0.19);
     font-size: 1.2em;
     height: 40px;
     margin-bottom: 20px;
     padding: 25px 6px;
+    cursor: text;
 }
 
 input[type="submit"],
@@ -70,27 +69,18 @@ input[type="submit"],
     margin-top: 10px;
     margin-bottom: 30px;
     padding: 10px 10px;
-}
-
-input[type="submit"]:hover,
-#btn-random:hover {
-    background: var(--light-blue);
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2),
-        0 1.5px 2px 0 rgba(0, 0, 0, 0.19);
+    cursor: pointer;
 }
 
 textarea:focus,
-input[type="text"]:focus {
-    border-color: rgba(0, 0, 0, 0.2);
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 3px 10px 0 rgba(0, 0, 0, 0.19);
-    outline: 0 none;
-}
-
+input[type="text"]:focus,
 textarea:hover,
 input[type="text"]:hover {
     border-color: rgba(0, 0, 0, 0.2);
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 3px 10px 0 rgba(0, 0, 0, 0.19);
-    outline: 0 none;
+    box-shadow:
+        0 2px 4px 0 rgba(0, 0, 0, 0.2),
+        0 3px 10px 0 rgba(0, 0, 0, 0.19);
+    outline: none;
 }
 
 .fa {
@@ -121,7 +111,9 @@ input[type="text"]:hover {
 
 .ui-widget.ui-widget-content {
     border-color: #888;
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 3px 10px 0 rgba(0, 0, 0, 0.19);
+    box-shadow:
+        0 2px 4px 0 rgba(0, 0, 0, 0.2),
+        0 3px 10px 0 rgba(0, 0, 0, 0.19);
     outline: 0 none;
 }
 
@@ -141,8 +133,8 @@ a.ui-button:active,
 
 input[type="submit"]:hover,
 #btn-random:hover {
-    background: var(--light-blue);
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2),
+    box-shadow:
+        0 1px 2px 0 rgba(0, 0, 0, 0.2),
         0 1.5px 2px 0 rgba(0, 0, 0, 0.19);
-    transition: background 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    transition: box-shadow 0.3s ease-in-out;
 }

--- a/src/pens/fcc-projects/build-a-wikipedia-viewer/index.html
+++ b/src/pens/fcc-projects/build-a-wikipedia-viewer/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" dir="ltr">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
             name="description"
-            content="This project is a Wikipedia Viewer created as part of the freeCodeCamp challenge, 'Build a Wikipedia Viewer'. It enables users to search for Wikipedia articles and view search results through the interface."
+            content="A Wikipedia viewer built for the freeCodeCamp challenge. Search for articles or open a random one, with jQuery UI autocomplete."
         />
         <meta name="keywords" content="HTML, CSS, JavaScript, jQuery" />
         <meta name="author" content="Karl Horning" />
@@ -26,85 +26,81 @@
         <link rel="stylesheet" href="./css/styles.css" />
     </head>
     <body>
-        <div class="search-background">
-            <div class="container">
+        <main>
+            <div class="search-background">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-md-12 text-center">
+                            <div role="img" aria-label="freeCodeCamp logo">
+                                <i class="fa fa-free-code-camp"></i>
+                            </div>
+                        </div>
+                    </div>
+
+                    <form onsubmit="return false;">
+                        <div class="row">
+                            <div class="col-md-3"></div>
+
+                            <div class="col-md-6">
+                                <input
+                                    id="q"
+                                    class="form-control"
+                                    type="text"
+                                    placeholder="Search Wikipedia for..."
+                                    maxlength="1000"
+                                    autocomplete="off"
+                                    autofocus
+                                    required
+                                />
+                            </div>
+
+                            <div class="col-md-3"></div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-3"></div>
+
+                            <div class="col-md-3">
+                                <input
+                                    id="btn-search"
+                                    class="btn-block"
+                                    type="submit"
+                                    value="Search Wikipedia"
+                                />
+                            </div>
+
+                            <div class="col-md-3">
+                                <input
+                                    id="btn-random"
+                                    class="btn-block"
+                                    type="button"
+                                    value="Random Article"
+                                />
+                            </div>
+
+                            <div class="col-md-3"></div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="wiki container">
                 <div class="row">
-                    <div class="col-md-12 text-center">
-                        <a
-                            href="javascript:window.location.href=window.location.href"
-                            ><i class="fa fa-free-code-camp"></i
-                        ></a>
+                    <div class="col-md-12">
+                        <ul id="wikiArticles"></ul>
                     </div>
                 </div>
-
-                <form onsubmit="return false">
-                    <div class="row">
-                        <div class="col-md-3"></div>
-
-                        <div class="col-md-6">
-                            <input
-                                id="q"
-                                class="form-control"
-                                type="text"
-                                placeholder="Search Wikipedia for..."
-                                maxlength="1000"
-                                value=""
-                                autocomplete="off"
-                                autofocus="on"
-                                tabindex="1"
-                                required
-                            />
-                        </div>
-
-                        <div class="col-md-3"></div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-3"></div>
-
-                        <div class="col-md-3">
-                            <input
-                                id="btn-search"
-                                class="btn-block"
-                                type="submit"
-                                value="Search Wikipedia"
-                                tabindex="2"
-                            />
-                        </div>
-
-                        <div class="col-md-3">
-                            <input
-                                id="btn-random"
-                                class="btn-block"
-                                type="button"
-                                value="Random Article"
-                                tabindex="3"
-                                onclick="window.open('https://en.wikipedia.org/wiki/Special:Random','blank','resizable=yes')"
-                            />
-                        </div>
-
-                        <div class="col-md-3"></div>
-                    </div>
-                </form>
             </div>
-        </div>
-
-        <div class="wiki container">
-            <div class="row">
-                <div class="col-md-12">
-                    <ul id="wikiArticles"></ul>
-                </div>
-            </div>
-        </div>
+        </main>
 
         <footer class="footer">
             <div class="container text-center">
                 <small>
-                    &copy; 2019 -
-                    <script type="text/javascript">
-                        document.write(new Date().getFullYear());
-                    </script>
-                    <a href="https://codepen.io/karlhorning" target="_blank"
+                    &copy; 2019 - <span id="current-year"></span>
+                    <a
+                        href="https://codepen.io/karlhorning"
+                        target="_blank"
+                        rel="noopener noreferrer"
                         >Karl Horning</a
                     >, All Rights Reserved
                 </small>
@@ -121,6 +117,6 @@
             integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
             crossorigin="anonymous"
         ></script>
-        <script type="text/javascript" src="./js/script.js"></script>
+        <script src="./js/script.js"></script>
     </body>
 </html>

--- a/src/pens/fcc-projects/build-a-wikipedia-viewer/js/script.js
+++ b/src/pens/fcc-projects/build-a-wikipedia-viewer/js/script.js
@@ -1,22 +1,32 @@
-// searchbar
+document.getElementById("current-year").textContent = new Date().getFullYear();
+
+// Search
 $(document).ready(function () {
+    $("#btn-random").click(function () {
+        window.open(
+            "https://en.wikipedia.org/wiki/Special:Random",
+            "_blank",
+            "resizable=yes"
+        );
+    });
+
     $("#btn-search").click(function () {
-        var $searchBackground = $(".search-background");
-        var $footer = $(".footer");
-        var $wiki = $(".wiki");
-        var $wikiArticles = $("#wikiArticles");
-        var query = $("#q").val();
+        const $searchBackground = $(".search-background");
+        const $footer = $(".footer");
+        const $wiki = $(".wiki");
+        const $wikiArticles = $("#wikiArticles");
+        let query = $("#q").val();
 
         if (query == "") query = "nothing";
-        var wikiApiUrl =
+        const wikiApiUrl =
             "https://en.wikipedia.org/w/api.php?action=opensearch&search=" +
             query +
             "&format=json&callback=?";
 
-        // Remove previous query
+        // Remove previous results
         $wikiArticles.text("");
 
-        // close the autocomplete so it's not in the users way if they wrote their own query
+        // Close autocomplete so it's not in the user's way
         $("#q").autocomplete("close");
 
         $wiki.css("min-height", "80vh");
@@ -29,7 +39,7 @@ $(document).ready(function () {
         $footer.css("margin-top", "20px");
         $footer.css("padding", "20px 0");
 
-        var wikiRequestTimeout = setTimeout(function () {
+        const wikiRequestTimeout = setTimeout(function () {
             $wikiArticles.text(
                 "Sorry, the Wikipedia articles cannot be loaded as your request timed out."
             );
@@ -41,21 +51,21 @@ $(document).ready(function () {
             type: "GET",
         })
             .done(function (data) {
-                wikiArticlesLength = data[1].length;
+                const wikiArticlesLength = data[1].length;
 
                 if (wikiArticlesLength == 0) {
                     $wikiArticles.append(
                         "Sorry, <b>" + query + "</b> returned no results."
                     );
                 } else {
-                    for (var i = 0; i < wikiArticlesLength; i++) {
-                        var articleTitle = data[1][i];
-                        var articleSnippet = data[2][i];
-                        var articleUrl = data[3][i];
+                    for (let i = 0; i < wikiArticlesLength; i++) {
+                        const articleTitle = data[1][i];
+                        const articleSnippet = data[2][i];
+                        const articleUrl = data[3][i];
                         $(
                             '<li><h3><a href="' +
                                 articleUrl +
-                                '" target="blank">' +
+                                '" target="_blank" rel="noopener noreferrer">' +
                                 articleTitle +
                                 '</a></h3><p class="url">' +
                                 articleUrl +
@@ -67,28 +77,27 @@ $(document).ready(function () {
                     $(
                         '<li><h3><a href="https://en.wikipedia.org/w/index.php?title=Special:Search&profile=default&fulltext=1&search=' +
                             query +
-                            '" target="blank">See all search results for <b>' +
+                            '" target="_blank" rel="noopener noreferrer">See all search results for <b>' +
                             query +
                             "</b> on Wikipedia...</a></h3></li>"
                     ).appendTo($wikiArticles);
                 }
                 clearTimeout(wikiRequestTimeout);
             })
-            .fail(function (errorMsg) {
+            .fail(function () {
                 $wikiArticles.text(
                     "Sorry, the Wikipedia articles cannot be loaded as the request failed."
                 );
-                console.log(errorMsg);
             });
     });
     return false;
 });
 
-// autocomplete
+// Autocomplete
 $("#q").autocomplete({
     source: function (request, response) {
         $.ajax({
-            url: "http://en.wikipedia.org/w/api.php",
+            url: "https://en.wikipedia.org/w/api.php",
             dataType: "jsonp",
             data: {
                 action: "opensearch",


### PR DESCRIPTION
- streamline description
- add `main` landmark
- remove tab indexes
- update script to get current year
- add `rel="noopener noreferrer"` to links that open in new tabs
- remove duplicate classes
- sentence case docs
- use `let` and `const` instead of `var`
- add `https` where missing
- other minor fixes