### PR TITLE
refactor: fixes for animated download button svg

### DIFF
--- a/src/pens/javascript/animated-download-button-svg/index.html
+++ b/src/pens/javascript/animated-download-button-svg/index.html
@@ -14,13 +14,7 @@
             href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
             rel="stylesheet"
         />
-        <link
-            rel="preload"
-            href="./styles.css"
-            as="style"
-            onload="this.onload=null;this.rel='stylesheet'"
-        />
-        <noscript><link rel="stylesheet" href="./styles.css" /></noscript>
+        <link rel="stylesheet" href="./styles.css" />
     </head>
 
     <body>
@@ -30,6 +24,7 @@
                 id="downloadButton"
             >
                 <button
+                    type="button"
                     class="bg-blue-500 hover:bg-blue-400 text-white font-bold py-3 px-8 rounded transition-transform duration-300 ease-in-out group-hover:transform group-hover:translate-y-1 relative"
                 >
                     <svg
@@ -37,14 +32,8 @@
                         width="18"
                         viewBox="0 0 80 80"
                         xmlns="http://www.w3.org/2000/svg"
-                        xml:space="preserve"
-                        style="
-                            fill-rule: evenodd;
-                            clip-rule: evenodd;
-                            stroke-linejoin: round;
-                            stroke-miterlimit: 2;
-                        "
                         class="inline-block mr-1"
+                        aria-hidden="true"
                     >
                         <g
                             id="download"
@@ -52,22 +41,19 @@
                         >
                             <path
                                 d="M790.556 271.2h30v50.981h240.654v-50.988h30v80.988H790.556V271.2Z"
-                                style="fill: #fff"
                                 id="bottom_section"
                             />
                             <path
                                 d="m955.886 224.256 79.534-69.534 19.75 22.585-114.284 99.911-114.281-99.911 19.745-22.585 11.293 9.873 68.243 59.661V26.611h30v197.645Z"
-                                style="fill: #fff"
                                 id="arrow"
                             />
                         </g>
                     </svg>
                     Download
-                    <span class="ripple"></span>
                 </button>
             </section>
         </main>
 
-        <script src="./script.js" defer></script>
+        <script src="./script.js"></script>
     </body>
 </html>

--- a/src/pens/javascript/animated-download-button-svg/script.js
+++ b/src/pens/javascript/animated-download-button-svg/script.js
@@ -1,53 +1,29 @@
 (() => {
-    /**
-     * Duration of the ripple animation in milliseconds.
-     * @type {number}
-     */
     const ANIMATION_DURATION = 600;
 
-    /**
-     * Animates a ripple effect on the clicked button.
-     *
-     * @param {MouseEvent} e - The mouse click event.
-     */
     const animateButton = (e) => {
-        // Get the button container
         const container = e.currentTarget;
-
-        // Create a span element for the ripple effect
         const rippleElement = document.createElement("span");
         rippleElement.classList.add("ripple");
 
-        // Calculate position and size of the ripple
         const rect = container.getBoundingClientRect();
         const size = Math.max(rect.width, rect.height);
         const x = e.clientX - rect.left - size / 2;
         const y = e.clientY - rect.top - size / 2;
 
-        // Apply styles to the ripple element
         rippleElement.style.width = `${size}px`;
         rippleElement.style.height = `${size}px`;
         rippleElement.style.top = `${y}px`;
         rippleElement.style.left = `${x}px`;
 
-        // Append the ripple element to the container
         container.appendChild(rippleElement);
 
-        // Remove the ripple element after the animation duration
         setTimeout(() => {
             rippleElement.remove();
         }, ANIMATION_DURATION);
     };
 
-    /**
-     * Event handler for the button click event.
-     *
-     * @param {MouseEvent} e - The mouse click event.
-     */
-    const handleClick = (e) => {
-        animateButton(e);
-    };
-
-    // Add a click event listener to the download button
-    downloadButton.addEventListener("click", handleClick);
+    document
+        .getElementById("downloadButton")
+        .addEventListener("click", animateButton);
 })();

--- a/src/pens/javascript/animated-download-button-svg/styles.css
+++ b/src/pens/javascript/animated-download-button-svg/styles.css
@@ -1,20 +1,22 @@
-/* Container for the ripple effect */
 .ripple-container {
     overflow: hidden;
     position: relative;
 }
 
-/* Ripple effect styling */
 .ripple {
     animation: ripple-animation 0.6s linear;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.6);
     position: absolute;
     transform: scale(0);
-    transform-origin: 50% 50%; /* Center the ripple effect */
+    transform-origin: 50% 50%;
 }
 
-/* Keyframes for the ripple animation */
+#bottom_section,
+#arrow {
+    fill: #fff;
+}
+
 @keyframes ripple-animation {
     to {
         opacity: 0;
@@ -22,12 +24,10 @@
     }
 }
 
-/* Arrow animation on button hover */
 button:hover #arrow {
     animation: down-animation 0.9s ease-in-out infinite;
 }
 
-/* Keyframes for the downward arrow animation */
 @keyframes down-animation {
     0% {
         transform: translateY(0);
@@ -38,7 +38,12 @@ button:hover #arrow {
     }
 }
 
-/* Arrow animation on button hover (consistent selector syntax) */
-button:hover #arrow {
-    animation: down-animation 0.9s ease-in-out infinite;
+@media (prefers-reduced-motion: reduce) {
+    .ripple {
+        animation: none;
+    }
+
+    button:hover #arrow {
+        animation: none;
+    }
 }


### PR DESCRIPTION
- remove unneeded `preload` and `defer`
- remove unneeded SVG properties
- add `aria-hidden="true"` to SVG
- move inline styles to stylesheet
- respect prefers reduced motion
- remove unneeded docs
- other minor updates